### PR TITLE
add dark mode support for native navigation headers

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout() {
 
   if (error) {
     return (
-      <View className="flex-1 justify-center items-center">
+      <View className="flex-1 justify-center items-center bg-white dark:bg-zinc-900">
         <Text className="text-red-500">Migration error: {error.message}</Text>
       </View>
     );
@@ -22,8 +22,8 @@ export default function RootLayout() {
 
   if (!success) {
     return (
-      <View className="flex-1 justify-center items-center">
-        <Text>Loading...</Text>
+      <View className="flex-1 justify-center items-center bg-white dark:bg-zinc-900">
+        <Text className="text-zinc-900 dark:text-white">Loading...</Text>
       </View>
     );
   }

--- a/app/subscriptions/_layout.tsx
+++ b/app/subscriptions/_layout.tsx
@@ -1,8 +1,20 @@
 import { router, Stack } from "expo-router";
+import { useColorScheme } from "react-native";
 
 export default function SubscriptionLayout() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+
+  const headerTintColor = isDark ? "#ffffff" : "#000000";
+  const headerLargeTitleStyle = { color: isDark ? "#ffffff" : "#000000" };
+
   return (
-    <Stack>
+    <Stack
+      screenOptions={{
+        headerTintColor,
+        headerLargeTitleStyle,
+      }}
+    >
       <Stack.Screen
         name="index"
         options={{

--- a/app/transactions/_layout.tsx
+++ b/app/transactions/_layout.tsx
@@ -1,8 +1,20 @@
 import { Stack } from "expo-router";
+import { useColorScheme } from "react-native";
 
 export default function TransactionsLayout() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+
+  const headerTintColor = isDark ? "#ffffff" : "#000000";
+  const headerLargeTitleStyle = { color: isDark ? "#ffffff" : "#000000" };
+
   return (
-    <Stack>
+    <Stack
+      screenOptions={{
+        headerTintColor,
+        headerLargeTitleStyle,
+      }}
+    >
       <Stack.Screen
         name="index"
         options={{


### PR DESCRIPTION
- Add useColorScheme hook to subscriptions and transactions layouts
- Set headerTintColor and headerLargeTitleStyle based on color scheme
- Add dark mode backgrounds and text colors to root layout loading/error states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark mode styling now applied to loading and error screens for a consistent visual experience.
  * Headers automatically adapt their appearance based on the current light or dark color scheme across subscriptions and transactions sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->