### PR TITLE
group transactions by month with sticky section headers

### DIFF
--- a/components/DomainLogo.native.tsx
+++ b/components/DomainLogo.native.tsx
@@ -55,7 +55,8 @@ export default function DomainLogo({
   return (
     <View
       className={cn(
-        "items-center justify-center overflow-hidden rounded-xl bg-zinc-100 dark:bg-zinc-800",
+        "items-center justify-center overflow-hidden rounded-xl ",
+        !logoUri ? "bg-zinc-100 dark:bg-zinc-800" : "bg-white",
         className,
       )}
       style={dimensionStyle}


### PR DESCRIPTION
Transactions are now grouped by month/year with sticky section headers
that display the month name and year (e.g., "Januar 2025"). Uses FlashList's
getItemType for optimized rendering and stickyHeaderIndices for headers
that stick to the top while scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction list is grouped by calendar month with persistent month/year section headers and monthly totals.
  * Transactions display domain, name, date, category chips, optional subscription indicator, and amount.
* **Performance**
  * Grouped data is memoized for smoother scrolling and faster list updates.
* **Style**
  * Header and item layout refinements and conditional logo background handling for improved visuals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->