### PR TITLE
Clean up old EAS branch and deployment before deploying new preview

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,11 @@ jobs:
       - name: Build server routes
         run: bunx expo export --platform web --no-ssg
 
-      - name: Remove old deployment
+      - name: Remove old previews
         continue-on-error: true
-        run: eas deploy:delete "pr-${{ github.event.pull_request.number }}" --non-interactive
+        run: |
+          eas branch:delete "pr-${{ github.event.pull_request.number }}" --non-interactive || true
+          eas deploy:delete "pr-${{ github.event.pull_request.number }}" --non-interactive || true
 
       - name: Deploy preview server routes
         run: eas deploy --id "pr-${{ github.event.pull_request.number }}" --environment preview --non-interactive


### PR DESCRIPTION
This ensures a clean slate for each PR preview by removing both the
EAS update branch and server routes deployment before creating new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request preview cleanup: now removes both preview branches and associated deployments for more thorough cleanup and fewer orphaned resources.

* **Documentation**
  * Renamed the public-facing documentation file to the updated product name to reflect rebranding; no behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->